### PR TITLE
Add PHPCS and bump minimum PHP version to 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor/*
+.idea/

--- a/classes/Exceptions/SMSMessageException.php
+++ b/classes/Exceptions/SMSMessageException.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MessageCloud\Gateway\Exceptions;
 
-class SMSMessageException extends \Exception
+use Exception;
+
+class SMSMessageException extends Exception
 {
 }

--- a/classes/Request.php
+++ b/classes/Request.php
@@ -1,21 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MessageCloud\Gateway;
 
-use Monolog\Logger;
-use Monolog\Handler\RotatingFileHandler;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
 use MessageCloud\Gateway\Exceptions\SMSMessageException;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Logger;
+use Ramsey\Uuid\Uuid;
 
 abstract class Request
 {
-    const GATEWAY_API_ENDPOINT = 'http://client.txtnation.com/gateway.php';
+    public const GATEWAY_API_ENDPOINT = 'http://client.txtnation.com/gateway.php';
 
-    const DEFAULT_LOG_LOCATION = '../logs/messages.txt';
-    const DEFAULT_MAX_LOG_FILES = 7;
+    public const DEFAULT_LOG_LOCATION = '../logs/messages.txt';
+    public const DEFAULT_MAX_LOG_FILES = 7;
 
     protected $objLogger = null;
 
@@ -23,7 +24,11 @@ abstract class Request
 
     public function startLogging()
     {
-        $this->objLogger->pushHandler(new RotatingFileHandler(self::DEFAULT_LOG_LOCATION, self::DEFAULT_MAX_LOG_FILES, Logger::WARNING));
+        $this->objLogger->pushHandler(new RotatingFileHandler(
+            self::DEFAULT_LOG_LOCATION,
+            self::DEFAULT_MAX_LOG_FILES,
+            Logger::WARNING
+        ));
     }
 
     public function send()
@@ -48,7 +53,7 @@ abstract class Request
             'encoding' => $this->strEncoding,
             'number' => $this->strMsisdn,
             'id' => $this->strId,
-            'reply' => $this->intReply
+            'reply' => $this->intReply,
         ];
 
         if ($this->blBinary) {
@@ -71,9 +76,9 @@ abstract class Request
             RequestOptions::SYNCHRONOUS => true,
             RequestOptions::ALLOW_REDIRECTS => true,
             RequestOptions::HEADERS => [
-                'User-agent' => 'MessageCloudGatewayLibraryPHP/1.0'
+                'User-agent' => 'MessageCloudGatewayLibraryPHP/1.0',
             ],
-            RequestOptions::HTTP_ERRORS => false
+            RequestOptions::HTTP_ERRORS => false,
         ]);
 
         $objResult = new SMSMessageResult($objResponse);

--- a/classes/Result.php
+++ b/classes/Result.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MessageCloud\Gateway;
 
 use Teapot\StatusCode;
@@ -10,10 +12,11 @@ abstract class Result
 
     public function success()
     {
-        return ((StatusCode::OK === $this->objResult->getStatusCode()) && ($this->strSuccess === (string) $this->objResult->getBody()));
+        return ((StatusCode::OK === $this->objResult->getStatusCode())
+            && ($this->strSuccess === (string) $this->objResult->getBody()));
     }
 
-    abstract function getErrorCode();
+    abstract public function getErrorCode();
 
-    abstract function getErrorMessage();
+    abstract public function getErrorMessage();
 }

--- a/classes/SMSMessage.php
+++ b/classes/SMSMessage.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MessageCloud\Gateway;
 
-use Monolog\Logger;
 use MessageCloud\Gateway\Exceptions\SMSMessageException;
+use Monolog\Logger;
 use Respect\Validation\Validator;
 
 class SMSMessage extends Request
 {
-    const LOGGING = 'logging';
+    public const LOGGING = 'logging';
 
-    const DEFAULT_FREE_NETWORK = 'INTERNATIONAL';
-    const DEFAULT_CURRENCY = 'GBP';
-    const DEFAULT_VALUE = 0.00;
-    const DEFAULT_REPLY = 0;
+    public const DEFAULT_FREE_NETWORK = 'INTERNATIONAL';
+    public const DEFAULT_CURRENCY = 'GBP';
+    public const DEFAULT_VALUE = 0.00;
+    public const DEFAULT_REPLY = 0;
 
     protected $strUsername = null;
     protected $strPassword = null;
@@ -31,7 +33,7 @@ class SMSMessage extends Request
     protected $strUdh = null;
 
     protected $arrOptions = [
-        self::LOGGING => true
+        self::LOGGING => true,
     ];
 
     public function __construct($strUsername, $strPassword, $arrOptions = [])
@@ -53,9 +55,9 @@ class SMSMessage extends Request
     public function msisdn($strMsisdn)
     {
         if (!(Validator::numeric()->notEmpty()->length(10, 12)->not(Validator::startsWith('0'))->validate($strMsisdn))) {
-            $this->objLogger->addError('MSISDN must be a numeric string between 10 and 12 characters long in international format');
-
-            throw new SMSMessageException('MSISDN must be a numeric string between 10 and 12 characters long in international format');
+            $errorText = 'MSISDN must be a numeric string between 10 and 12 characters long in international format';
+            $this->objLogger->addError($errorText);
+            throw new SMSMessageException($errorText);
         }
 
         $this->strMsisdn = $strMsisdn;
@@ -236,7 +238,7 @@ class SMSMessage extends Request
             $this->objLogger->addWarning('No message was set on the outgoing message');
         }
 
-        if (0.0 === (float)$this->fltValue && is_null($this->strNetwork)) {
+        if (0.0 === (float) $this->fltValue && is_null($this->strNetwork)) {
             $this->objLogger->addDebug('Automatically setting the network to INTERNATIONAL for a 0 value message');
 
             $this->strNetwork = self::DEFAULT_FREE_NETWORK;

--- a/classes/SMSMessageResult.php
+++ b/classes/SMSMessageResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MessageCloud\Gateway;
 
 use Psr\Http\Message\ResponseInterface;
@@ -12,40 +14,41 @@ class SMSMessageResult extends Result
     protected $strId;
 
     // a few error codes
-    const ERROR_NO_CREDITS = 'NO CREDITS';
-    const ERROR_BARRED = 'BARRED';
+    public const ERROR_NO_CREDITS = 'NO CREDITS';
+    public const ERROR_BARRED = 'BARRED';
 
-    const ERROR_IR_101 = 'IR-101';
-    const ERROR_IR_102 = 'IR-102';
-    const ERROR_IR_103 = 'IR-103';
-    const ERROR_IR_104 = 'IR-104';
+    public const ERROR_IR_101 = 'IR-101';
+    public const ERROR_IR_102 = 'IR-102';
+    public const ERROR_IR_103 = 'IR-103';
+    public const ERROR_IR_104 = 'IR-104';
 
-    const ERROR_IR_401 = 'IR-401';
-    const ERROR_IR_403 = 'IR-403';
-    const ERROR_IR_404 = 'IR-404';
-    const ERROR_IR_405 = 'IR-405';
-    const ERROR_IR_409 = 'IR-409';
-    const ERROR_IR_410 = 'IR-410';
-    const ERROR_IR_412 = 'IR-412';
-    const ERROR_IR_413 = 'IR-413';
-    const ERROR_IR_414 = 'IR-414';
-    const ERROR_IR_415 = 'IR-415';
-    const ERROR_IR_416 = 'IR-416';
-    const ERROR_IR_417 = 'IR-417';
-    const ERROR_IR_418 = 'IR-418';
-    const ERROR_IR_419 = 'IR-419';
-    const ERROR_IR_420 = 'IR-420';
+    public const ERROR_IR_401 = 'IR-401';
+    public const ERROR_IR_403 = 'IR-403';
+    public const ERROR_IR_404 = 'IR-404';
+    public const ERROR_IR_405 = 'IR-405';
+    public const ERROR_IR_409 = 'IR-409';
+    public const ERROR_IR_410 = 'IR-410';
+    public const ERROR_IR_412 = 'IR-412';
+    public const ERROR_IR_413 = 'IR-413';
+    public const ERROR_IR_414 = 'IR-414';
+    public const ERROR_IR_415 = 'IR-415';
+    public const ERROR_IR_416 = 'IR-416';
+    public const ERROR_IR_417 = 'IR-417';
+    public const ERROR_IR_418 = 'IR-418';
+    public const ERROR_IR_419 = 'IR-419';
+    public const ERROR_IR_420 = 'IR-420';
 
-    const ERROR_E_100 = 'E-100';
-    const ERROR_E_101 = 'E-101';
-    const ERROR_E_102 = 'E-102';
-    const ERROR_E_103 = 'E-103';
-    const ERROR_E_105 = 'E-105';
-    const ERROR_E_107 = 'E-107';
-    const ERROR_E_108 = 'E-108';
-    const ERROR_E_109 = 'E-109';
+    public const ERROR_E_100 = 'E-100';
+    public const ERROR_E_101 = 'E-101';
+    public const ERROR_E_102 = 'E-102';
+    public const ERROR_E_103 = 'E-103';
+    public const ERROR_E_105 = 'E-105';
+    public const ERROR_E_107 = 'E-107';
+    public const ERROR_E_108 = 'E-108';
+    public const ERROR_E_109 = 'E-109';
 
-    const ERROR_UNKNOWN = 'Unrecognised error code returned. Please contact MessageCloud Support at help@messagecloud.com for more assistance.';
+    // phpcs:disable Generic.Files.LineLength.MaxExceeded
+    public const ERROR_UNKNOWN = 'Unrecognised error code returned. Please contact MessageCloud Support at help@messagecloud.com for more assistance.';
 
 
     // how the error codes translate into real person speak
@@ -80,8 +83,9 @@ class SMSMessageResult extends Result
         self::ERROR_E_105 => 'Invalid Operator ID.',
         self::ERROR_E_107 => 'Invalid Test. Please review your settings.',
         self::ERROR_E_108 => 'Sending failed as you have no credits remaining on your account.',
-        self::ERROR_E_109 => 'Sending through your account via MessageCloud is currently disabled in this country.'
+        self::ERROR_E_109 => 'Sending through your account via MessageCloud is currently disabled in this country.',
     ];
+    // phpcs:enable
 
     protected $objResult;
 
@@ -115,6 +119,8 @@ class SMSMessageResult extends Result
 
     public function getErrorMessage()
     {
-        return (!empty($this->arrErrorMessages[$this->strErrorCode])) ? $this->arrErrorMessages[$this->strErrorCode] : self::ERROR_UNKNOWN;
+        return !empty($this->arrErrorMessages[$this->strErrorCode])
+            ? $this->arrErrorMessages[$this->strErrorCode]
+            : self::ERROR_UNKNOWN;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		}
 	],
 	"require":{
-		"php": ">=5.4.0",
+		"php": ">=7.2",
 		"ext-curl": "*",
 		"ext-mbstring": "*",
 		"monolog/monolog": "^1.13",
@@ -28,11 +28,18 @@
 		"ramsey/uuid": "^3.3"
 	},
 	"require-dev":{
-		"phpunit/phpunit": "~4.0"
+		"phpunit/phpunit": "~4.0",
+		"squizlabs/php_codesniffer": "^3.5",
+		"messagecloud/messagecloud-coding-standard": "^3.0"
 	},
 	"autoload":{
 		"psr-4":{
 			"MessageCloud\\Gateway\\": "classes/"
+		}
+	},
+	"autoload-dev":{
+		"psr-4":{
+			"MessageCloudTest\\Gateway\\": "tests/"
 		}
 	},
 	"scripts":{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6acc6ce17142c2f6881f9f0c0aa78438",
+    "content-hash": "1df89edf62f201caee52f5dc87198fd2",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -803,6 +803,74 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^5.3|^7",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "wimg/php-compatibility": "^8.0"
+            },
+            "suggest": {
+                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "f.nijhof@dealerdirect.nl",
+                    "homepage": "http://workingatdealerdirect.eu",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://workingatdealerdirect.eu",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "time": "2017-12-06T16:27:17+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
             "source": {
@@ -855,6 +923,42 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "messagecloud/messagecloud-coding-standard",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MessageCloud/messagecloud-coding-standard.git",
+                "reference": "7ebddf50eafed42ae3c77e148cd00cc6e230fedf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MessageCloud/messagecloud-coding-standard/zipball/7ebddf50eafed42ae3c77e148cd00cc6e230fedf",
+                "reference": "7ebddf50eafed42ae3c77e148cd00cc6e230fedf",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "slevomat/coding-standard": "^5.0",
+                "squizlabs/php_codesniffer": "^3.0"
+            },
+            "require-dev": {
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "authors": [
+                {
+                    "name": "Ethan Bray",
+                    "email": "e.bray@txtnation.com"
+                }
+            ],
+            "description": "MessageCloud Coding Standard",
+            "time": "2019-10-08T13:08:46+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -966,6 +1070,53 @@
                 "stub"
             ],
             "time": "2016-02-15T07:46:21+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/8c4ef2aefd9788238897b678a985e1d5c8df6db4",
+                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan": "^0.10",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2",
+                "symfony/process": "^3.4 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "time": "2019-06-07T19:13:52+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1708,6 +1859,97 @@
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
+            "name": "slevomat/coding-standard",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/287ac3347c47918c0bf5e10335e36197ea10894c",
+                "reference": "287ac3347c47918c0bf5e10335e36197ea10894c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpstan/phpdoc-parser": "^0.3.1",
+                "squizlabs/php_codesniffer": "^3.4.1"
+            },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "phing/phing": "2.16.1",
+                "phpstan/phpstan": "0.11.4",
+                "phpstan/phpstan-phpunit": "0.11",
+                "phpstan/phpstan-strict-rules": "0.11",
+                "phpunit/phpunit": "8.0.5"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "time": "2019-03-22T19:10:53+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-09-26T23:12:26+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v3.0.4",
             "source": {
@@ -1763,7 +2005,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4.0",
+        "php": ">=7.2",
         "ext-curl": "*",
         "ext-mbstring": "*"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ruleset name="MessageCloud Coding Standard">
+    <rule ref="./vendor/messagecloud/messagecloud-coding-standard/ruleset.xml"/>
+
+    <file>./classes/</file>
+    <file>./tests/</file>
+</ruleset>

--- a/tests/SMSMessageTest.php
+++ b/tests/SMSMessageTest.php
@@ -1,14 +1,20 @@
 <?php
 
-require_once 'vendor/autoload.php';
+declare(strict_types=1);
+
+namespace MessageCloudTest\Gateway;
 
 use MessageCloud\Gateway\SMSMessage;
+use PHPUnit_Framework_TestCase;
+use stdClass;
 
-class SMSMessageTest extends \PHPUnit_Framework_TestCase
+class SMSMessageTest extends PHPUnit_Framework_TestCase
 {
+    private $objMessage;
+
     public function setUp()
     {
-        $this->objMessage = new SMSMessage('Marc','test');
+        $this->objMessage = new SMSMessage('Marc', 'test');
     }
 
     public function tearDown()
@@ -30,7 +36,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidMsisdnReturnsSMSMessageObject($input)
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->msisdn($input));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->msisdn($input));
     }
 
     public function providerForValidMsisdn()
@@ -38,7 +44,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
         return [
             ['447528748500'],
             ['44752874850'],
-            ['353857025834']
+            ['353857025834'],
         ];
     }
 
@@ -51,7 +57,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
             ['444752874850000'],
             ['60999'],
             [[]],
-            [new stdClass]
+            [new stdClass()],
         ];
     }
 
@@ -69,7 +75,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIdReturnsSMSMessageObject($input)
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->id($input));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->id($input));
     }
 
     public function providerForValidId()
@@ -79,7 +85,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
             ['12345'],
             [md5('12345')],
             [sha1('12345')],
-            ['de305d54-75b4-431b-adb2-eb6b9e546014']
+            ['de305d54-75b4-431b-adb2-eb6b9e546014'],
         ];
     }
 
@@ -88,7 +94,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
         return [
             [''],
             [[]],
-            [new stdClass]
+            [new stdClass()],
         ];
     }
 
@@ -106,7 +112,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidBodyReturnsSMSMessageObject($input)
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->body($input));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->body($input));
     }
 
     public function providerForValidBody()
@@ -114,7 +120,8 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
         return [
             [''],
             ['Hello, world!'],
-            ['This is a long message that will represent a concatenated message for the sake of this unit test. Concatenated messages are normally over 160 characters long and are automatically handled by MessageCloud.']
+            ['This is a long message that will represent a concatenated message for the sake of this unit test. 
+            Concatenated messages are normally over 160 characters long and are automatically handled by MessageCloud.'],
         ];
     }
 
@@ -122,7 +129,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
     {
         return [
             [[]],
-            [new stdClass]
+            [new stdClass()],
         ];
     }
 
@@ -140,7 +147,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidSenderIdReturnsSMSMessageObject($input)
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->senderId($input));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->senderId($input));
     }
 
     public function providerForValidSenderId()
@@ -148,7 +155,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
         return [
             ['MessageCloud'],
             ['447528748500'],
-            ['07528748500']
+            ['07528748500'],
         ];
     }
 
@@ -160,7 +167,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
             ['+447528748500'],
             ['00447528748500'],
             [[]],
-            [new stdClass]
+            [new stdClass()],
         ];
     }
 
@@ -178,7 +185,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValueReturnsSMSMessageObject($input)
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->value($input));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->value($input));
     }
 
     public function providerForValidValue()
@@ -189,7 +196,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
             [0],
             [10],
             [12.5],
-            [100]
+            [100],
         ];
     }
 
@@ -199,7 +206,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
             [-1],
             ['-10'],
             [[]],
-            [new stdClass]
+            [new stdClass()],
         ];
     }
 
@@ -213,7 +220,7 @@ class SMSMessageTest extends \PHPUnit_Framework_TestCase
 
     public function testNetworkReturnsSMSMessageObject()
     {
-        $this->assertInstanceOf('MessageCloud\Gateway\SMSMessage', $this->objMessage->network('international'));
+        $this->assertInstanceOf(SMSMessage::class, $this->objMessage->network('international'));
     }
 
     /**


### PR DESCRIPTION
Our coding standard requires `declare(strict_types=1)` so I bumped us up to 7.2 while I was at it.

Closes #10.
Related to #15.