### PR TITLE
Remove dependency on monolog/monolog dependency

### DIFF
--- a/classes/SMSMessage.php
+++ b/classes/SMSMessage.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace MessageCloud\Gateway;
 
 use MessageCloud\Gateway\Exceptions\SMSMessageException;
-use Monolog\Logger;
+use Psr\Log\NullLogger;
 use Respect\Validation\Validator;
 
 class SMSMessage extends Request
 {
     public const LOGGING = 'logging';
+    public const LOGGER  = 'logger';
 
     public const DEFAULT_FREE_NETWORK = 'INTERNATIONAL';
     public const DEFAULT_CURRENCY = 'GBP';
@@ -19,6 +20,7 @@ class SMSMessage extends Request
 
     protected $arrOptions = [
         self::LOGGING => true,
+        self::LOGGER  => null,
     ];
 
     public function __construct($strUsername, $strPassword, $arrOptions = [])
@@ -28,26 +30,25 @@ class SMSMessage extends Request
 
         $this->arrOptions = array_merge($this->arrOptions, $arrOptions);
 
-        $this->objLogger = new Logger(__CLASS__);
-
-        if ($this->arrOptions[self::LOGGING]) {
-            $this->startLogging();
+        if ($this->arrOptions[self::LOGGER] === null) {
+            $this->arrOptions[self::LOGGER] = new NullLogger();
         }
 
-        $this->objLogger->addDebug('Message object constructed');
+        $this->setLogger($this->arrOptions[self::LOGGER]);
+        $this->objLogger->debug('Message object constructed');
     }
 
     public function msisdn($strMsisdn)
     {
         if (!(Validator::numeric()->notEmpty()->length(10, 12)->not(Validator::startsWith('0'))->validate($strMsisdn))) {
             $errorText = 'MSISDN must be a numeric string between 10 and 12 characters long in international format';
-            $this->objLogger->addError($errorText);
+            $this->objLogger->error($errorText);
             throw new SMSMessageException($errorText);
         }
 
         $this->strMsisdn = $strMsisdn;
 
-        $this->objLogger->addDebug('MSISDN has been set to ' . $strMsisdn);
+        $this->objLogger->debug('MSISDN has been set to ' . $strMsisdn);
 
         return $this;
     }
@@ -55,14 +56,14 @@ class SMSMessage extends Request
     public function id($strId)
     {
         if (!(Validator::stringType()->notEmpty()->validate($strId))) {
-            $this->objLogger->addError('ID must be a string');
+            $this->objLogger->error('ID must be a string');
 
             throw new SMSMessageException('ID must be a string');
         }
 
         $this->strId = $strId;
 
-        $this->objLogger->addDebug('ID has been set to ' . $strId);
+        $this->objLogger->debug('ID has been set to ' . $strId);
 
         return $this;
     }
@@ -70,14 +71,14 @@ class SMSMessage extends Request
     public function body($strBody)
     {
         if (!(Validator::stringType()->validate($strBody))) {
-            $this->objLogger->addError('Message body must be a string');
+            $this->objLogger->error('Message body must be a string');
 
             throw new SMSMessageException('Message body must be a string');
         }
 
         $this->strBody = $strBody;
 
-        $this->objLogger->addDebug('Message body has been set to ' . $strBody);
+        $this->objLogger->debug('Message body has been set to ' . $strBody);
 
         return $this;
     }
@@ -85,14 +86,14 @@ class SMSMessage extends Request
     public function senderId($strSenderId)
     {
         if (!(Validator::stringType()->notEmpty()->length(1, 12)->validate($strSenderId))) {
-            $this->objLogger->addError('SenderId must be a string between 1 and 12 characters long');
+            $this->objLogger->error('SenderId must be a string between 1 and 12 characters long');
 
             throw new SMSMessageException('SenderId must be a string between 1 and 12 characters long');
         }
 
         $this->strSenderId = $strSenderId;
 
-        $this->objLogger->addDebug('Sender ID has been set to ' . $strSenderId);
+        $this->objLogger->debug('Sender ID has been set to ' . $strSenderId);
 
         return $this;
     }
@@ -100,14 +101,14 @@ class SMSMessage extends Request
     public function network($strNetwork)
     {
         if (!(Validator::stringType()->notEmpty()->length(1, 50)->validate($strNetwork))) {
-            $this->objLogger->addError('Network must be a string');
+            $this->objLogger->error('Network must be a string');
 
             throw new SMSMessageException('Network must be a string');
         }
 
         $this->strNetwork = $strNetwork;
 
-        $this->objLogger->addDebug('Network has been set to ' . $strNetwork);
+        $this->objLogger->debug('Network has been set to ' . $strNetwork);
 
         return $this;
     }
@@ -115,14 +116,14 @@ class SMSMessage extends Request
     public function value($fltValue)
     {
         if (!(Validator::floatVal()->min(0, true)->validate($fltValue))) {
-            $this->objLogger->addError('Value must be a floating point number');
+            $this->objLogger->error('Value must be a floating point number');
 
             throw new SMSMessageException('Value must be a floating point number');
         }
 
         $this->fltValue = (float) $fltValue;
 
-        $this->objLogger->addDebug('Value has been set to ' . $fltValue);
+        $this->objLogger->debug('Value has been set to ' . $fltValue);
 
         return $this;
     }
@@ -130,14 +131,14 @@ class SMSMessage extends Request
     public function currency($strCurrency)
     {
         if (!(Validator::stringType()->notEmpty()->length(3, 3)->validate($strCurrency))) {
-            $this->objLogger->addError('Currency should be in ISO 4217 standard, e.g. USD, EUR, GBP');
+            $this->objLogger->error('Currency should be in ISO 4217 standard, e.g. USD, EUR, GBP');
 
             throw new SMSMessageException('Currency should be in ISO 4217 standard, e.g. USD, EUR, GBP');
         }
 
         $this->strCurrency = $strCurrency;
 
-        $this->objLogger->addDebug('Currency has been set to ' . $strCurrency);
+        $this->objLogger->debug('Currency has been set to ' . $strCurrency);
 
         return $this;
     }
@@ -145,14 +146,14 @@ class SMSMessage extends Request
     public function reply($intReply)
     {
         if (!(Validator::intType()->between(0, 1)->validate($intReply))) {
-            $this->objLogger->addError('Reply must be 1 or 0');
+            $this->objLogger->error('Reply must be 1 or 0');
 
             throw new SMSMessageException('Reply must be 1 or 0');
         }
 
         $this->intReply = (int) $intReply;
 
-        $this->objLogger->addDebug('Reply has been set to ' . $intReply);
+        $this->objLogger->debug('Reply has been set to ' . $intReply);
 
         return $this;
     }
@@ -160,14 +161,14 @@ class SMSMessage extends Request
     public function udh($strUdh)
     {
         if (!(Validator::stringType()->notEmpty()->length(1, 255)->validate($strUdh))) {
-            $this->objLogger->addError('UDH must be a string');
+            $this->objLogger->error('UDH must be a string');
 
             throw new SMSMessageException('UDH must be a string');
         }
 
         $this->strUdh = $strUdh;
 
-        $this->objLogger->addDebug('UDH has been set to ' . $strUdh);
+        $this->objLogger->debug('UDH has been set to ' . $strUdh);
 
 
         return $this;
@@ -176,14 +177,14 @@ class SMSMessage extends Request
     public function binary($blBinary)
     {
         if (!(Validator::boolType()->validate($blBinary))) {
-            $this->objLogger->addError('Binary must be TRUE or FALSE');
+            $this->objLogger->error('Binary must be TRUE or FALSE');
 
             throw new SMSMessageException('Binary must be TRUE or FALSE');
         }
 
         $this->blBinary = (bool) $blBinary;
 
-        $this->objLogger->addDebug('Binary has been set to ' . $blBinary);
+        $this->objLogger->debug('Binary has been set to ' . $blBinary);
 
         return $this;
     }
@@ -191,64 +192,64 @@ class SMSMessage extends Request
     public function category($intCategory)
     {
         if (!(Validator::numeric()->notEmpty()->length(3, 3)->validate($intCategory))) {
-            $this->objLogger->addError('Category must be a numeric string with a length of 3.');
+            $this->objLogger->error('Category must be a numeric string with a length of 3.');
 
             throw new SMSMessageException('Category must be a numeric string with a length of 3.');
         }
 
         $this->intCategory = $intCategory;
 
-        $this->objLogger->addDebug('Category has been set to ' . $intCategory);
+        $this->objLogger->debug('Category has been set to ' . $intCategory);
 
         return $this;
     }
 
     protected function validate()
     {
-        $this->objLogger->addDebug('Validating the request');
+        $this->objLogger->debug('Validating the request');
 
         if (!$this->strMsisdn) {
-            $this->objLogger->addError('MSISDN must be set');
+            $this->objLogger->error('MSISDN must be set');
 
             throw new SMSMessageException('MSISDN must be set');
         }
 
         if (!$this->strSenderId) {
-            $this->objLogger->addError('Sender ID must be set');
+            $this->objLogger->error('Sender ID must be set');
 
             throw new SMSMessageException('Sender ID must be set');
         }
 
         if (!$this->strBody) {
-            $this->objLogger->addWarning('No message was set on the outgoing message');
+            $this->objLogger->warning('No message was set on the outgoing message');
         }
 
         if (0.0 === (float) $this->fltValue && is_null($this->strNetwork)) {
-            $this->objLogger->addDebug('Automatically setting the network to INTERNATIONAL for a 0 value message');
+            $this->objLogger->debug('Automatically setting the network to INTERNATIONAL for a 0 value message');
 
             $this->strNetwork = self::DEFAULT_FREE_NETWORK;
         }
 
         if (is_null($this->strCurrency)) {
-            $this->objLogger->addDebug('Automatically setting the currency to ' . self::DEFAULT_CURRENCY);
+            $this->objLogger->debug('Automatically setting the currency to ' . self::DEFAULT_CURRENCY);
 
             $this->strCurrency = self::DEFAULT_CURRENCY;
         }
 
         if (is_null($this->fltValue)) {
-            $this->objLogger->addDebug('Automatically setting the message value to ' . self::DEFAULT_VALUE);
+            $this->objLogger->debug('Automatically setting the message value to ' . self::DEFAULT_VALUE);
 
             $this->fltValue = self::DEFAULT_VALUE;
         }
 
         if (is_null($this->intReply)) {
-            $this->objLogger->addDebug('Automatically setting the reply value to ' . self::DEFAULT_REPLY);
+            $this->objLogger->debug('Automatically setting the reply value to ' . self::DEFAULT_REPLY);
 
             $this->intReply = self::DEFAULT_REPLY;
         }
 
         if ((strtoupper(self::DEFAULT_FREE_NETWORK) === strtoupper($this->strNetwork)) && (0.00 < $this->fltValue)) {
-            $this->objLogger->addError('Free messages cannot have a value');
+            $this->objLogger->error('Free messages cannot have a value');
 
             throw new SMSMessageException('Free messages cannot have a value');
         }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
 	"name": "messagecloud/gateway-php",
 	"description": "A PHP library to help you integrate the MessageCloud Gateway.",
+	"license": "MIT",
 	"keywords": ["sms", "mobile", "billing", "phone", "cell", "text"],
 	"homepage": "http://www.messagecloud.com",
 	"time": "2016-04-29",
@@ -21,10 +22,10 @@
 		"php": ">=7.2",
 		"ext-curl": "*",
 		"ext-mbstring": "*",
-		"monolog/monolog": "^1.13",
 		"guzzlehttp/guzzle": "^6.2",
 		"respect/validation": "^1.0",
-		"ramsey/uuid": "^3.3"
+		"ramsey/uuid": "^3.3",
+		"psr/log": "^1.1"
 	},
 	"require-dev":{
 		"phpunit/phpunit": "^8.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4edeaf48adfa17aab0cfcc4a1acd5340",
+    "content-hash": "d14054de2484478bcda9db8fc316ce22",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -178,84 +178,6 @@
             "time": "2016-04-13T19:56:01+00:00"
         },
         {
-            "name": "monolog/monolog",
-            "version": "1.19.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                "reference": "5f56ed5212dc509c8dc8caeba2715732abb32dbf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
-            },
-            "provide": {
-                "psr/log-implementation": "1.0.0"
-            },
-            "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9",
-                "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "jakub-onderka/php-parallel-lint": "0.9",
-                "php-amqplib/php-amqplib": "~2.4",
-                "php-console/php-console": "^3.1.3",
-                "phpunit/phpunit": "~4.5",
-                "phpunit/phpunit-mock-objects": "2.3.0",
-                "raven/raven": "^0.13",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "swiftmailer/swiftmailer": "~5.3"
-            },
-            "suggest": {
-                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
-                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
-                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
-                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
-                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
-                "raven/raven": "Allow sending log messages to a Sentry server",
-                "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Monolog\\": "src/Monolog"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
-            "keywords": [
-                "log",
-                "logging",
-                "psr-3"
-            ],
-            "time": "2016-04-12T18:29:35+00:00"
-        },
-        {
             "name": "paragonie/random_compat",
             "version": "v2.0.2",
             "source": {
@@ -355,22 +277,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
+                "reference": "bf73deb2b3b896a9d9c75f3f0d88185d2faa27e2",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -384,12 +314,13 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21T11:40:51+00:00"
+            "time": "2019-10-25T08:06:51+00:00"
         },
         {
             "name": "ramsey/uuid",


### PR DESCRIPTION
This removes our dependency on `monolog/monolog` by accepting any PSR-3 compliant logger. This involved renaming all of our current `add*` usage as that is Monolog specific and not provided by the PSR-3 `LoggerInterface`.

By default a `NullLogger` will be set instead of the previous Monolog logger with the `RotatingFileHandler`. As the log setter is part of the `Request`, it does introduce a situation where NPE's may occur as the `objLogger` property will be null if the child class does not call `setLogger`. However since we currently only have one class extending `Request` and I'm not planning on tagging this release, I'm happy to leave this as is and it can be cleaned up in a later PR.

In later pull requests I will also remove other unnecessary dependencies.

We were missing licensing information in the `composer.json` file so I added that too.