### PR TITLE
Add type hinting to success method in Result class

### DIFF
--- a/classes/Result.php
+++ b/classes/Result.php
@@ -9,7 +9,7 @@ abstract class Result
     protected $objResult;
     protected $strSuccess = 'OK';
 
-    public function success()
+    public function success(): bool
     {
         return (200 === $this->objResult->getStatusCode()
             && ($this->strSuccess === (string) $this->objResult->getBody()));


### PR DESCRIPTION
As this class uses `declare(strict_types=1);` and the `success` method always returns a boolean. I've type hinted the return value to be `bool`.